### PR TITLE
Add sleeps and failsafes and safe modes

### DIFF
--- a/conf/machine/wren.conf
+++ b/conf/machine/wren.conf
@@ -22,4 +22,4 @@ KERNEL_IMAGETYPE = "zImage-dtb"
 IMAGE_FSTYPES += "ext4"
 IMAGE_ROOTFS_ALIGNMENT="4"
 
-IMAGE_INSTALL += "android-tools android-system msm-fb-refresher brcm-patchram-plus"
+IMAGE_INSTALL += "android-tools android-system msm-fb-refresher brcm-patchram-plus servicemanager usb-moded-extra"

--- a/recipes-android/servicemanager/servicemanager/reinit-servicemanager.service
+++ b/recipes-android/servicemanager/servicemanager/reinit-servicemanager.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Reinit servicemanager after some time
+
+[Service]
+Type=simple
+ExecStartPre=/bin/sh -ec 'while [ ! -f /dev/.coldboot_done ]; do sleep 1; done; sleep 10'
+ExecStart=/system/bin/servicemanager
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-android/servicemanager/servicemanager_1.0.bb
+++ b/recipes-android/servicemanager/servicemanager_1.0.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "This installs an extra service which loads /system/bin/servicemanager"
+PR = "r0"
+SRC_URI = "file://reinit-servicemanager.service"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+S = "${WORKDIR}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+    install -d ${D}/lib/systemd/system/multi-user.target.wants/
+
+    cp ${WORKDIR}/reinit-servicemanager.service ${D}/lib/systemd/system/
+    ln -s ../reinit-servicemanager.service ${D}/lib/systemd/system/multi-user.target.wants/reinit-servicemanager.service
+}
+
+FILES_${PN} += "/lib/systemd/system/"

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher.service
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=The wayland compositors and desktop of AsteroidOS
+Requires=dbus.socket
+
+[Service]
+Type=notify
+EnvironmentFile=-/var/lib/environment/compositor/*.conf
+ExecStartPre=/bin/sh -ec 'while [ ! -f /dev/.coldboot_done ]; do sleep 1; done; sleep 5;'
+ExecStart=/usr/bin/asteroid-launcher $LIPSTICK_OPTIONS --systemd
+TimeoutStopSec=3
+Restart=always
+
+[Install]
+WantedBy=default.target

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bbappend
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend_wren := "${THISDIR}/${PN}:"

--- a/recipes-nemomobile/usb-moded-extra/usb-moded-extra/add-broken-args.conf
+++ b/recipes-nemomobile/usb-moded-extra/usb-moded-extra/add-broken-args.conf
@@ -1,0 +1,1 @@
+export USB_MODED_ARGS="-i -a"

--- a/recipes-nemomobile/usb-moded-extra/usb-moded-extra_1.0.bb
+++ b/recipes-nemomobile/usb-moded-extra/usb-moded-extra_1.0.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "This installs a config file to make usb-moded work on wren"
+PR = "r0"
+SRC_URI = "file://add-broken-args.conf"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+S = "${WORKDIR}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+    install -d ${D}/var/lib/environment/usb-moded/
+
+    cp ${WORKDIR}/add-broken-args.conf ${D}/var/lib/environment/usb-moded/
+}
+
+FILES_${PN} += "/var/lib/environment/usb-moded/"


### PR DESCRIPTION
I am not terribly proud of this pull request. Without these changes the watch boots to the Asteroid logo splash screen, but no wayland session and no rndis / any other terminal connection. Adding sleeps isn't _really_ the best way to solve issues, but with these changes at least the watch _works_.

* Run usb_moded in "ignore errors and continue with broken kernels mode"
* Restart servicemanager some time after boot as it dies the first time around
* Only start asteroid-launcher after waiting some time, as otherwise it aborts
  with a message about a failed hwcomposer