### PR TITLE
linux: Add kernel modules to image.

### DIFF
--- a/recipes-kernel/linux/linux-wren_mm-mr1.bb
+++ b/recipes-kernel/linux/linux-wren_mm-mr1.bb
@@ -41,6 +41,8 @@ do_install_append() {
     rm -rf ${D}/usr/src/usr/
 }
 
+IMAGE_INSTALL += " kernel-modules"
+
 BOOT_PARTITION = "/dev/mmcblk0p11"
 
 inherit mkboot old-kernel-gcc-hdrs


### PR DESCRIPTION
Turns out that this port doesn't package the kernel modules.
This patch fixes sensors not working.
Big thanks to @hummlbach for providing help in fixing this issue!

This one is not tested, but wren and sparrow seem similar enough. The kernel config option CONFIG_SENSORS_SENTRAL_IIO=m indicates that the sensor kernel module is build during kernel compilation.